### PR TITLE
Add lint hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,3 +18,13 @@
   types: [sql]
   require_serial: true
   additional_dependencies: []
+- id: sqlfluff-conda-lint
+  name: sqlfluff-conda
+  # Needs to use "--force" to disable confirmation
+  # By default all the rules are applied
+  entry: sqlfluff lint --force
+  language: conda
+  description: 'Lint SQL files with `SQLFluff`'
+  types: [sql]
+  require_serial: true
+  additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,16 @@
   # By default all the rules are applied
   entry: sqlfluff fix --force
   language: conda
+  description: 'Fixes sql lint errors with `SQLFluff` (DEPRECATED: Please use `sqlfluff-conda-fix` instead)'
+  types: [sql]
+  require_serial: true
+  additional_dependencies: []
+- id: sqlfluff-conda-fix
+  name: sqlfluff-conda
+  # Needs to use "--force" to disable confirmation
+  # By default all the rules are applied
+  entry: sqlfluff fix --force
+  language: conda
   description: 'Fixes sql lint errors with `SQLFluff`'
   types: [sql]
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,9 +20,7 @@
   additional_dependencies: []
 - id: sqlfluff-conda-lint
   name: sqlfluff-conda
-  # Needs to use "--force" to disable confirmation
-  # By default all the rules are applied
-  entry: sqlfluff lint --force
+  entry: sqlfluff lint
   language: conda
   description: 'Lint SQL files with `SQLFluff`'
   types: [sql]

--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ Add this to your `.pre-commit-config.yaml`
  - repo: https://github.com/Quantco/pre-commit-mirrors-sqlfluff
    rev: ''  # Use the sha / tag you want to point at
    hooks:
-     - id: sqlfluff-conda
+     - id: sqlfluff-conda-fix
+     - id: sqlfluff-conda-lint
 ```


### PR DESCRIPTION
We have the need for a `sqlfluff lint` hook. To keep the hook ids aligned we renamed `sqlfluff-conda` to `sqlfluff-conda-fix`.