### PR TITLE
Add lint hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,15 @@
   # By default all the rules are applied
   entry: sqlfluff fix --force
   language: conda
-  description: 'Fixes sql lint errors with `SQLFluff`'
+  description: "Fixes sql lint errors with `SQLFluff`"
+  types: [sql]
+  require_serial: true
+  additional_dependencies: []
+- id: sqlfluff-conda-lint
+  name: sqlfluff-conda
+  entry: sqlfluff lint
+  language: conda
+  description: "Lints sql files with `SQLFluff`"
   types: [sql]
   require_serial: true
   additional_dependencies: []


### PR DESCRIPTION
This PR adds `sqlfluff-conda-lint` as an additional hook. I did _not_ rename the "fix" hook since it should be the default.

The "lint" hook is only useful for the time being as SQLFluff does not list errors on `sqlfluff fix`.
