### PR TITLE
Autoupdate: Add convenience `git tag` command

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -41,7 +41,13 @@ jobs:
           title: "Update ${{ steps.versions.outputs.pkgname }} to ${{ steps.versions.outputs.new-version }}"
           body: |
             A new release of ${{ steps.versions.outputs.pkgname }} was detected on conda-forge.
+
             This PR updates ${{ steps.versions.outputs.pkgname }} to version ${{ steps.versions.outputs.new-version }}.
-            **After merging, please manually create and push a ${{ steps.versions.outputs.new-version }} tag.**
+
+            **After merging, please manually create and push a ${{ steps.versions.outputs.new-version }} tag:**
+
+            ```
+            bash -xc 'tmp=$(mktemp -d) && git clone ${{ github.server_url }}/${{ github.repository }} $tmp && cd $tmp && git tag ${{ steps.versions.outputs.new-version }} && git push --tags'
+            ```
           branch: v${{ steps.versions.outputs.new-version }}
           delete-branch: true


### PR DESCRIPTION
Any reason not to have this?